### PR TITLE
Resolve threshold_density in associndex

### DIFF
--- a/R/All_internal.R
+++ b/R/All_internal.R
@@ -219,12 +219,11 @@ pre_associndex_UNISITE_UNI <- function(int_data = NULL) {
 
 # associndex_UNISITE_UNI()
 
-associndex_UNISITE_UNI <- function(int_data = NULL) {
+associndex_UNISITE_UNI <- function(int_data = NULL, threshold_density = NULL) {
 
   if (!"Open" %in% int_data$Canopy) stop("tests cannot be conducted because your data does not contain a node named Open or it is spelled differently.")
 
-
-
+  
   # Assemble the data
   db_inter <- pre_associndex_UNISITE_UNI(int_data)
 
@@ -232,7 +231,16 @@ associndex_UNISITE_UNI <- function(int_data = NULL) {
   db_inter$Dcr <- db_inter$Fcr/db_inter$Ac
   db_inter$Dro <- db_inter$Fro/db_inter$Ao
 
-   #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
+  # Retain the interactions with estimated density below the threshold.
+  unique_Dro <- stats::aggregate(Dro ~ Recruit, data = db_inter[, c("Recruit", "Dro")], mean)
+  y <- c(db_inter$Dcr,unique_Dro$Dro)
+  threshold_density = max(y)+1
+  thr <- threshold_density
+  
+  
+  db_inter <- db_inter[which(db_inter$Dcr<thr & db_inter$Dro<thr), ]
+
+  #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
   db_inter$Max_Recr_Density <- pmax(db_inter$Dcr,db_inter$Dro)
 
   db_inter <- utils::type.convert(db_inter, as.is = TRUE)
@@ -1102,10 +1110,12 @@ pre_associndex_UNISITE_BI_COMP <- function(int_data = NULL) {
 # associndex_p() use pre_associndex_non_expand instead of pre_associndex and
 #remove line to remove a column named "Frequency" that does not exist
 
-associndex_UNISITE_BI <- function(int_data = NULL) {
+associndex_UNISITE_BI <- function(int_data = NULL,
+                                  threshold_density = NULL) {
 
   if (!"Open" %in% int_data$Canopy) stop("tests cannot be conducted because your data does not contain a node named Open or it is spelled differently.")
 
+  
   # Assemble the data
   db_inter <- pre_associndex_UNISITE_BI(int_data)
 
@@ -1113,6 +1123,13 @@ associndex_UNISITE_BI <- function(int_data = NULL) {
   db_inter$Dcr <- db_inter$Fcr/db_inter$Ac
   db_inter$Dro <- db_inter$Fro/db_inter$Ao
 
+  # Retain the interactions with estimated density below the threshold.
+  unique_Dro <- stats::aggregate(Dro ~ Recruit, data = db_inter[, c("Recruit", "Dro")], mean)
+  y <- c(db_inter$Dcr,unique_Dro$Dro)
+  threshold_density = max(y)+1
+  thr <- threshold_density
+  
+  db_inter <- db_inter[which(db_inter$Dcr<thr & db_inter$Dro<thr), ]
 
   #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
   db_inter$Max_Recr_Density <- pmax(db_inter$Dcr,db_inter$Dro)
@@ -1155,7 +1172,8 @@ associndex_UNISITE_BI <- function(int_data = NULL) {
 # associndex_p() use pre_associndex_non_expand instead of pre_associndex and
 #remove line to remove a column named "Frequency" that does not exist
 
-associndex_UNISITE_BI_COMP <- function(int_data = NULL) {
+associndex_UNISITE_BI_COMP <- function(int_data = NULL,
+                                       threshold_density = NULL) {
 
   if (!"Open" %in% int_data$Canopy) stop("tests cannot be conducted because your data does not contain a node named Open or it is spelled differently.")
 
@@ -1167,6 +1185,15 @@ associndex_UNISITE_BI_COMP <- function(int_data = NULL) {
   db_inter$Dcr <- db_inter$Fcr/db_inter$Ac
   db_inter$Dro <- db_inter$Fro/db_inter$Ao
 
+  # Retain the interactions with estimated density below the threshold.
+  unique_Dro <- stats::aggregate(Dro ~ Recruit, data = db_inter[, c("Recruit", "Dro")], mean)
+  y <- c(db_inter$Dcr,unique_Dro$Dro)
+  threshold_density = max(y)+1
+  thr <- threshold_density
+  
+  
+  
+  db_inter <- db_inter[which(db_inter$Dcr<thr & db_inter$Dro<thr), ]
 
   #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
   db_inter$Max_Recr_Density <- pmax(db_inter$Dcr,db_inter$Dro)

--- a/R/All_internal.R
+++ b/R/All_internal.R
@@ -234,11 +234,11 @@ associndex_UNISITE_UNI <- function(int_data = NULL, threshold_density = NULL) {
   # Retain the interactions with estimated density below the threshold.
   unique_Dro <- stats::aggregate(Dro ~ Recruit, data = db_inter[, c("Recruit", "Dro")], mean)
   y <- c(db_inter$Dcr,unique_Dro$Dro)
-  threshold_density = max(y)+1
-  thr <- threshold_density
+#  threshold_density = max(y)+1
+#  thr <- threshold_density
   
   
-  db_inter <- db_inter[which(db_inter$Dcr<thr & db_inter$Dro<thr), ]
+  db_inter <- db_inter[which(db_inter$Dcr<threshold_density & db_inter$Dro<threshold_density), ]
 
   #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
   db_inter$Max_Recr_Density <- pmax(db_inter$Dcr,db_inter$Dro)
@@ -1126,10 +1126,10 @@ associndex_UNISITE_BI <- function(int_data = NULL,
   # Retain the interactions with estimated density below the threshold.
   unique_Dro <- stats::aggregate(Dro ~ Recruit, data = db_inter[, c("Recruit", "Dro")], mean)
   y <- c(db_inter$Dcr,unique_Dro$Dro)
-  threshold_density = max(y)+1
-  thr <- threshold_density
+#  threshold_density = max(y)+1
+#  thr <- threshold_density
   
-  db_inter <- db_inter[which(db_inter$Dcr<thr & db_inter$Dro<thr), ]
+  db_inter <- db_inter[which(db_inter$Dcr<threshold_density & db_inter$Dro<threshold_density), ]
 
   #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
   db_inter$Max_Recr_Density <- pmax(db_inter$Dcr,db_inter$Dro)
@@ -1188,12 +1188,12 @@ associndex_UNISITE_BI_COMP <- function(int_data = NULL,
   # Retain the interactions with estimated density below the threshold.
   unique_Dro <- stats::aggregate(Dro ~ Recruit, data = db_inter[, c("Recruit", "Dro")], mean)
   y <- c(db_inter$Dcr,unique_Dro$Dro)
-  threshold_density = max(y)+1
-  thr <- threshold_density
+#  threshold_density = max(y)+1
+#  thr <- threshold_density
   
   
   
-  db_inter <- db_inter[which(db_inter$Dcr<thr & db_inter$Dro<thr), ]
+  db_inter <- db_inter[which(db_inter$Dcr<threshold_density & db_inter$Dro<threshold_density), ]
 
   #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
   db_inter$Max_Recr_Density <- pmax(db_inter$Dcr,db_inter$Dro)

--- a/R/All_internal.R
+++ b/R/All_internal.R
@@ -219,11 +219,11 @@ pre_associndex_UNISITE_UNI <- function(int_data = NULL) {
 
 # associndex_UNISITE_UNI()
 
-associndex_UNISITE_UNI <- function(int_data = NULL, threshold_density = NULL) {
+associndex_UNISITE_UNI <- function(int_data = NULL) {
 
   if (!"Open" %in% int_data$Canopy) stop("tests cannot be conducted because your data does not contain a node named Open or it is spelled differently.")
 
-  thr <- threshold_density
+
 
   # Assemble the data
   db_inter <- pre_associndex_UNISITE_UNI(int_data)
@@ -232,10 +232,7 @@ associndex_UNISITE_UNI <- function(int_data = NULL, threshold_density = NULL) {
   db_inter$Dcr <- db_inter$Fcr/db_inter$Ac
   db_inter$Dro <- db_inter$Fro/db_inter$Ao
 
-  # Retain the interactions with estimated density below the threshold.
-  db_inter <- db_inter[which(db_inter$Dcr<thr & db_inter$Dro<thr), ]
-
-  #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
+   #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
   db_inter$Max_Recr_Density <- pmax(db_inter$Dcr,db_inter$Dro)
 
   db_inter <- utils::type.convert(db_inter, as.is = TRUE)
@@ -1105,12 +1102,9 @@ pre_associndex_UNISITE_BI_COMP <- function(int_data = NULL) {
 # associndex_p() use pre_associndex_non_expand instead of pre_associndex and
 #remove line to remove a column named "Frequency" that does not exist
 
-associndex_UNISITE_BI <- function(int_data = NULL,
-                                  threshold_density = NULL) {
+associndex_UNISITE_BI <- function(int_data = NULL) {
 
   if (!"Open" %in% int_data$Canopy) stop("tests cannot be conducted because your data does not contain a node named Open or it is spelled differently.")
-
-  thr <- threshold_density
 
   # Assemble the data
   db_inter <- pre_associndex_UNISITE_BI(int_data)
@@ -1119,8 +1113,6 @@ associndex_UNISITE_BI <- function(int_data = NULL,
   db_inter$Dcr <- db_inter$Fcr/db_inter$Ac
   db_inter$Dro <- db_inter$Fro/db_inter$Ao
 
-  # Retain the interactions with estimated density below the threshold.
-  db_inter <- db_inter[which(db_inter$Dcr<thr & db_inter$Dro<thr), ]
 
   #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
   db_inter$Max_Recr_Density <- pmax(db_inter$Dcr,db_inter$Dro)
@@ -1163,12 +1155,10 @@ associndex_UNISITE_BI <- function(int_data = NULL,
 # associndex_p() use pre_associndex_non_expand instead of pre_associndex and
 #remove line to remove a column named "Frequency" that does not exist
 
-associndex_UNISITE_BI_COMP <- function(int_data = NULL,
-                                       threshold_density = NULL) {
+associndex_UNISITE_BI_COMP <- function(int_data = NULL) {
 
   if (!"Open" %in% int_data$Canopy) stop("tests cannot be conducted because your data does not contain a node named Open or it is spelled differently.")
 
-  thr <- threshold_density
 
   # Assemble the data
   db_inter <- pre_associndex_UNISITE_BI_COMP(int_data)
@@ -1177,8 +1167,6 @@ associndex_UNISITE_BI_COMP <- function(int_data = NULL,
   db_inter$Dcr <- db_inter$Fcr/db_inter$Ac
   db_inter$Dro <- db_inter$Fro/db_inter$Ao
 
-  # Retain the interactions with estimated density below the threshold.
-  db_inter <- db_inter[which(db_inter$Dcr<thr & db_inter$Dro<thr), ]
 
   #Obtain the maximum recruitment density for each recruit under the canopy species or in open.
   db_inter$Max_Recr_Density <- pmax(db_inter$Dcr,db_inter$Dro)

--- a/R/associndex.R
+++ b/R/associndex.R
@@ -101,7 +101,7 @@ associndex<- function(int_data, cover_data, expand=c("yes","no"),
   if(is.null(threshold_density)){
      # To effectively avoid the use of a threshold, we set its value to the maximum
      # observed density.
-         threshold_density = max(y)
+         threshold_density = max(y)+1
   }
 
   if(threshold_density == "Weibull"){

--- a/R/associndex.R
+++ b/R/associndex.R
@@ -98,13 +98,19 @@ associndex<- function(int_data, cover_data, expand=c("yes","no"),
      unique_Dro <- stats::aggregate(Dro ~ Recruit, data = db_inter_0[, c("Recruit", "Dro")], mean)
      y <- c(db_inter_0$Dcr,unique_Dro$Dro)
 
-  if(is.null(threshold_density)){
-     # To effectively avoid the use of a threshold, we set its value to the maximum
-     # observed density.
-         threshold_density = max(y)+1
+  # if threshold_density is a number, use it directly
+  if (is.numeric(threshold_density)) {
+    stopifnot(threshold_density >= 0)
+    stopifnot(threshold_density <= (max(y) + 1))
   }
 
-  if(threshold_density == "Weibull"){
+  if (is.null(threshold_density)) {
+     # To effectively avoid the use of a threshold, we set its value to the maximum
+     # observed density.
+         threshold_density = max(y) + 1
+  }
+
+  if (threshold_density == "Weibull") {
 
      # Suggest a threshold value based on recruitment density outliers according
      # to a Weibull distribution. Uses "extremevalues" package.


### PR DESCRIPTION
Remove the threshold_density from the internal functions related to associndex, which required a numerical input as argument, and therefore failed to run when "NULL" was assigned as the argument